### PR TITLE
Improve the performance of intercept_load

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The method takes in a hash into which a few options can be passed:
 * `safe_query_mode`: `:strict` or `:lax`; `:lax` mode allows usage of
   `RiskilyAssumeTrustedString` type.
 * `dry_run`: true/false, default to false; when set to true, only warnings
-  will be emitted but otherwise an exception will be raised when unconforming
+  will be emitted, an exception will not be raised when unconforming
   types are passed in.
 * `intercept_load`: true/false, default to false; when set to true,
   `require`/`load`/`require_relative` will be intercepted in order to

--- a/lib/safe_active_record/load.rb
+++ b/lib/safe_active_record/load.rb
@@ -22,7 +22,14 @@ module SafeActiveRecord
   @gemlist = Set.new
 
   def self.init_visited
-    @visited.merge($LOADED_FEATURES) if $LOADED_FEATURES.is_a? Enumerable
+    if $LOADED_FEATURES.is_a? Enumerable
+      @visited.merge($LOADED_FEATURES)
+      # Also merge the relative imported paths
+      $LOADED_FEATURES.each do |path|
+        $LOAD_PATH.each{ |start_path| @visited.add(path[start_path.size+1..-4]) if path.start_with?(start_path)}
+      end
+    end
+
     # Usually gem path starts with the gem name, exceptions incl. google gems
     @gemlist.merge(Gem::Specification.map { |g| g.name.start_with?('google-') ? 'google' : g.name })
   end

--- a/lib/safe_active_record/load.rb
+++ b/lib/safe_active_record/load.rb
@@ -20,31 +20,20 @@ require 'set'
 module SafeActiveRecord
   @@visited = Set.new
 
-  def self.init_visited()
-    @@visited.merge($LOADED_FEATURES)
-  end
-
-  def self.resolve_feature_path(args)
-    if args.instance_of?(Array) && args.size == 1 && args[0].instance_of?(String)
-      rfpath = $LOAD_PATH.resolve_feature_path(args[0])
-      if !rfpath.nil? && rfpath.size == 2 && rfpath[1].instance_of?(String)
-        return rfpath[1]
-      end
-      return args[0]
-    end
-    return nil
-  end
-
-  def self.skip_symbols_diff(path, method)
+  def self.skip_symbols_diff(args, method)
     # load is mainly used for development to reload code without restarting the app
     return false if method == "load"
-    return true if !path.nil? && (@@visited.include?(path) || path.start_with?(Gem.dir))
+    if args.instance_of?(Array) && args.size == 1 && args[0].instance_of?(String)
+      return true if (@@visited.include?(args[0]) || args[0].start_with?(Gem.dir))
+    end
     return false
   end
 
-  def self.visit(path, method)
+  def self.visit(args, method)
     return if method == "load"
-    @@visited.add(path) unless path.nil?
+    if args.instance_of?(Array) && args.size == 1 && args[0].instance_of?(String)
+      @@visited.add(args[0])
+    end
   end
 
   def self.apply_load_patch(safe_query_mgr)
@@ -64,15 +53,15 @@ module SafeActiveRecord
           undef_method original_method
 
           define_method original_method do |*args|
-            rfpath = SafeActiveRecord.resolve_feature_path(args)
-            if safe_query_mgr.activated? && safe_query_mgr.intercept_load? && !SafeActiveRecord.skip_symbols_diff(rfpath, "#{original_method}")
-              pre_symbols = Symbol.all_symbols
+            if safe_query_mgr.activated? && safe_query_mgr.intercept_load? && !SafeActiveRecord.skip_symbols_diff(args, "#{original_method}")
+              pre_symbols_len = Symbol.all_symbols.size
 
               result = method(:"safe_ar_original_#{original_method}").call(*args)
 
-              delta = Symbol.all_symbols - pre_symbols
-              safe_query_mgr.add_safe_queries delta
-              SafeActiveRecord.visit(rfpath, "#{original_method}")
+              if result
+                safe_query_mgr.add_safe_queries Symbol.all_symbols[pre_symbols_len...]
+              end
+              SafeActiveRecord.visit(args, "#{original_method}")
             else
               result = method(:"safe_ar_original_#{original_method}").call(*args)
             end
@@ -102,7 +91,14 @@ module SafeActiveRecord
           # decorated.
 
           abspath = "#{abspath}.rb" unless File.exist?(abspath)
-          require(File.realpath(abspath))
+          begin
+            require(File.realpath(abspath))
+          rescue
+            # TODO: fix this
+            abspath = File.expand_path(path, base)
+            abspath = "#{abspath}.so" unless File.exist?(abspath)
+            require(File.realpath(abspath))
+          end
         end
       end
     end

--- a/lib/safe_active_record/load.rb
+++ b/lib/safe_active_record/load.rb
@@ -26,6 +26,7 @@ module SafeActiveRecord
       @visited.merge($LOADED_FEATURES)
       # Also merge the relative imported paths
       $LOADED_FEATURES.each do |path|
+        # Add the relative path to the visited set, removing the base path from LOAD_PATH and the file extension
         $LOAD_PATH.each{ |start_path| @visited.add(path[start_path.size+1..-4]) if path.start_with?(start_path)}
       end
     end
@@ -79,6 +80,9 @@ module SafeActiveRecord
 
               if result
                 post_symbols = Symbol.all_symbols
+                # If the last symbol of the pre table is the same in the post table, this means only additions happened
+                # (no symbol deletion), so we can get the delta by slicing the post-table using the pre-table size as lower
+                # boundary
                 delta = if post_symbols[pre_symbols.size - 1] == pre_symbols[-1]
                           post_symbols[pre_symbols.size...]
                         else

--- a/lib/safe_active_record/load.rb
+++ b/lib/safe_active_record/load.rb
@@ -56,9 +56,11 @@ module SafeActiveRecord
 
               result = method(:"safe_ar_original_#{original_method}").call(*args)
 
-              delta = Symbol.all_symbols - pre_symbols
-              safe_query_mgr.add_safe_queries delta
-              SafeActiveRecord.visit(args)
+              post_symbols = Symbol.all_symbols
+              if post_symbols.size != pre_symbols.size
+                safe_query_mgr.add_safe_queries post_symbols[pre_symbols.size...]
+                SafeActiveRecord.visit(args)
+              end
             else
               result = method(:"safe_ar_original_#{original_method}").call(*args)
             end

--- a/lib/safe_active_record/load.rb
+++ b/lib/safe_active_record/load.rb
@@ -32,6 +32,7 @@ module SafeActiveRecord
     end
 
     # Usually gem path starts with the gem name, exceptions incl. google gems
+    # TODO: find a better way to do this without hardcoding specific use-cases
     @gemlist.merge(Gem::Specification.map { |g| g.name.start_with?('google-') ? 'google' : g.name })
   end
 

--- a/lib/safe_active_record/load.rb
+++ b/lib/safe_active_record/load.rb
@@ -27,7 +27,7 @@ module SafeActiveRecord
       # Also merge the relative imported paths
       $LOADED_FEATURES.each do |path|
         # Add the relative path to the visited set, removing the base path from LOAD_PATH and the file extension
-        $LOAD_PATH.each{ |start_path| @visited.add(path[start_path.size+1..-4]) if path.start_with?(start_path)}
+        $LOAD_PATH.each { |start_path| @visited.add(path[start_path.size + 1..-4]) if path.start_with?(start_path) }
       end
     end
 
@@ -120,6 +120,7 @@ module SafeActiveRecord
           # No need to calculate the delta of symbol since `require` is already
           # decorated.
 
+          # Both .rb and .so files can be imported. C extentions use .so files for example.
           abspath = "#{abspath}.rb" unless File.exist?(abspath)
           abspath = "#{abspath[...-3]}.so" unless File.exist?(abspath)
           require(File.realpath(abspath))

--- a/lib/safe_active_record/safe_query_manager.rb
+++ b/lib/safe_active_record/safe_query_manager.rb
@@ -63,6 +63,10 @@ module SafeActiveRecord
 
       end
 
+      # Add the current loaded dependencies to the visited global set
+      # This prevent intercept load to unprocess the symbole table for them
+      SafeActiveRecord.init_visited()
+
       add_safe_queries Symbol.all_symbols
 
       @safe_queries.freeze unless @options[:intercept_load]

--- a/lib/safe_active_record/safe_query_manager.rb
+++ b/lib/safe_active_record/safe_query_manager.rb
@@ -63,9 +63,9 @@ module SafeActiveRecord
 
       end
 
-      # Add the current loaded dependencies to the visited global set
-      # This prevent intercept load to unprocess the symbole table for them
-      SafeActiveRecord.init_visited()
+      # Add the current loaded dependencies to the visited global set to improve
+      # intercept load performance
+      SafeActiveRecord.init_visited if @options[:intercept_load]
 
       add_safe_queries Symbol.all_symbols
 

--- a/lib/safe_active_record/safe_query_manager.rb
+++ b/lib/safe_active_record/safe_query_manager.rb
@@ -63,10 +63,6 @@ module SafeActiveRecord
 
       end
 
-      # Add the current loaded dependencies to the visited global set
-      # This prevent intercept load to unprocess the symbole table for them
-      SafeActiveRecord.init_visited()
-
       add_safe_queries Symbol.all_symbols
 
       @safe_queries.freeze unless @options[:intercept_load]

--- a/lib/safe_active_record/safe_type.rb
+++ b/lib/safe_active_record/safe_type.rb
@@ -28,8 +28,11 @@ module SafeActiveRecord
       raise StandardErrors, "SafeQueryManager must be activated before instantiation of #{self.class.name}!" unless mgr.activated?
 
       unless mgr.safe_query?(str)
-        raise ArgumentError, "The symbol isn't found trusted. It could be that it is created dynamically from a string," \
-                             "or the source where the caller belongs to isn't eager loaded."
+        exception = ArgumentError.new(
+          "The symbol isn't found trusted when calling `#{caller_locations.first}`. It could be that it is created " \
+          "dynamically from a string, or the source where the caller belongs to isn't eager loaded.")
+        SafeActiveRecord.report_violation(exception)
+        raise exception unless mgr.dry_run?
       end
 
       @raw_str = str.to_s

--- a/lib/safe_active_record/safe_type.rb
+++ b/lib/safe_active_record/safe_type.rb
@@ -30,7 +30,8 @@ module SafeActiveRecord
       unless mgr.safe_query?(str)
         exception = ArgumentError.new(
           "The symbol isn't found trusted when calling `#{caller_locations.first}`. It could be that it is created " \
-          "dynamically from a string, or the source where the caller belongs to isn't eager loaded.")
+          "dynamically from a string, or the source where the caller belongs to isn't eager loaded."
+        )
         SafeActiveRecord.report_violation(exception)
         raise exception unless mgr.dry_run?
       end

--- a/spec/load_spec.rb
+++ b/spec/load_spec.rb
@@ -89,6 +89,14 @@ describe 'monkey patch Kernel.require load and requrie_relative,' do
       expect(mgr.safe_query?('relative load static query 1'.to_sym)).to be true
     end
 
+    it 'allows loading relative .so files' do
+      mgr = SafeActiveRecord::SafeQueryManager.new
+      SafeActiveRecord.apply_load_patch(mgr)
+      mgr.activate!({ intercept_load: true })
+
+      expect { require_relative('loaded_6') }.to raise_error(LoadError)
+    end
+
     after(:each) do
       remove_load_patch
     end


### PR DESCRIPTION
Includes the following changes:
* Don’t raise an exception in dry run when the safe type symbol isn't found trusted.
* Don’t process symbol table diff for gems, as SAR ignore SQL statements made in gems
* Don’t process symbol table diff for already processed "require" code paths
* Small performance improvement in the symbol table diff operation
* Small fix when using "require_relative" with .so files